### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "crunchy"
 version = "0.2.3"
 authors = ["Vurich <jackefransham@hotmail.co.uk>"]
 description = "Crunchy unroller: deterministically unroll constant loops"
+repository = "https://github.com/eira-fransham/crunchy"
 license = "MIT"
 build = "build.rs"
 


### PR DESCRIPTION
This adds the `repository` field to Cargo.toml, making it easier for crates.io users to find the repository hosting the crate's source code. This issue was found by scraping our indirect dependencies from crates.io and verifying that they meet certain criteria. Could a new patch release be made after this PR is merged?

Closes #5
Closes #9