### PR TITLE
Switch to forward slash for lib.rs path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,4 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(target_os = "windows")]
-include!(concat!(env!("OUT_DIR"), "\\lib.rs"));
-
-#[cfg(not(target_os = "windows"))]
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));


### PR DESCRIPTION
Windows supports forward slashes as directory separators. The use of a backslash here breaks building for Windows on Linux.